### PR TITLE
full.cache: add incr and decr for remote cache

### DIFF
--- a/full.cache/src/full/cache.clj
+++ b/full.cache/src/full/cache.clj
@@ -121,6 +121,28 @@
          (throw e)
          (log/warn k "not added to cache due to" e))))))
 
+(defn rincr
+  [k by timeout & {:keys [throw? default] :or {default 0}}]
+  (try
+    (let [res (.incr @client k by default timeout)]
+      (log/info "Incremented value for" k "by:" by "to" res)
+      res)
+    (catch Exception e
+      (if throw?
+        (throw e)
+        (log/warn k "not incremented due to" e)))))
+
+(defn rdecr
+  [k by timeout & {:keys [throw? default] :or {default 0}}]
+  (try
+    (let [res (.decr @client k by default timeout)]
+      (log/info "Decremented value for" k "by:" by "to" res)
+      res)
+    (catch Exception e
+      (if throw?
+        (throw e)
+        (log/warn k "not decremented due to" e)))))
+
 (defn radd-or-get
   ([k v] (radd-or-get k v 0))
   ([k v timeout & {:keys [throw?]}]

--- a/full.cache/src/full/cache.clj
+++ b/full.cache/src/full/cache.clj
@@ -106,6 +106,17 @@
          (log/warn k "not added to cache due to" e))))
    v))
 
+(defn rtouch
+  [k timeout & {:keys [throw?]}]
+  (try
+    (.touch @client k timeout)
+    (log/debug "Updated timeout for" k "to" timeout)
+    (catch Exception e
+      (if throw?
+        (throw e)
+        (log/warn k "not touched due to" e)))))
+
+
 (defn radd
   ([k v] (radd k v 0))
   ([k v timeout & {:keys [throw?]}]
@@ -125,7 +136,7 @@
   [k by timeout & {:keys [throw? default] :or {default 0}}]
   (try
     (let [res (.incr @client k by default timeout)]
-      (log/info "Incremented value for" k "by:" by "to" res)
+      (log/debug "Incremented value for" k "by:" by "to" res)
       res)
     (catch Exception e
       (if throw?
@@ -136,7 +147,7 @@
   [k by timeout & {:keys [throw? default] :or {default 0}}]
   (try
     (let [res (.decr @client k by default timeout)]
-      (log/info "Decremented value for" k "by:" by "to" res)
+      (log/debug "Decremented value for" k "by:" by "to" res)
       res)
     (catch Exception e
       (if throw?


### PR DESCRIPTION
Adding wrappers for `incr` and `decr` memcached commands.

Unlike the [docs say](https://code.google.com/p/memcached/wiki/NewCommands#incr/decr) they work fine with negative increments.

In order to battle with variadic overload runtime exceptions, default is added via kwarg and there is no overloading.

/cc @k7d @zarlen 