### PR TITLE
TravisCI: build with jdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: clojure
 install: lein sub install
 script: "lein sub midje"
 jdk:
-  - oraclejdk8
+  - oraclejdk7


### PR DESCRIPTION
EMR hadoop is still on good ol' jdk7 unfortunately. This should only really affect camelsnake, which is the one throwing java.lang.UnsupportedClassVersionError.

@k7d 