### PR TITLE
full.http.server - support streaming responses

### DIFF
--- a/camelsnake/project.clj
+++ b/camelsnake/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/camelsnake "0.7.5-SNAPSHOT"
+(defproject fullcontact/camelsnake "0.8.0-SNAPSHOT"
   :description "String and keyword transformation between cases."
 
   :url "https://github.com/fullcontact/full.monty"

--- a/full.async/project.clj
+++ b/full.async/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.async "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.async "0.8.0-SNAPSHOT"
   :description "Extensions and helpers for core.async."
 
   :url "https://github.com/fullcontact/full.monty"

--- a/full.aws/project.clj
+++ b/full.aws/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.aws "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.aws "0.8.0-SNAPSHOT"
   :description "Async Amazon Webservices client."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -14,13 +14,13 @@
                  [com.taoensso/faraday "1.7.1" ; DynamoDB sugar
                   :exclusions [com.amazonaws/aws-java-sdk-dynamodb joda-time]]
                  ; include full.time for joda-time dependency
-                 [fullcontact/full.time "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.metrics "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.http "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.json "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.edn "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.time "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.metrics "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.http "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.json "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.edn "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.bootstrap/project.clj
+++ b/full.bootstrap/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.bootstrap "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.bootstrap "0.8.0-SNAPSHOT"
   :description "Boostrap module that pulls in all commonly used full-monty dependencies."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -10,15 +10,15 @@
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.time "0.7.5-SNAPSHOT"]
-                 [fullcontact/camelsnake "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.json "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.dev "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.cache "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.metrics "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.http "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.time "0.8.0-SNAPSHOT"]
+                 [fullcontact/camelsnake "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.json "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.dev "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.cache "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.metrics "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.http "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.cache/project.clj
+++ b/full.cache/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.cache "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.cache "0.8.0-SNAPSHOT"
   :description "In-memory + memcache caching for Clojure with async loading."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -13,8 +13,8 @@
                  [net.jodah/expiringmap "0.4.1"]
                  [net.spy/spymemcached "2.12.0"]
                  [com.taoensso/nippy "2.9.0"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.core/project.clj
+++ b/full.core/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.core "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.core "0.8.0-SNAPSHOT"
   :description "FullContact's core Clojure library - logging, configuration and common helpers."
 
   :url "https://github.com/fullcontact/full.monty"

--- a/full.dev/project.clj
+++ b/full.dev/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.dev "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.dev "0.8.0-SNAPSHOT"
   :description "Clojure's development and debugging helpers"
 
   :url "https://github.com/fullcontact/full.monty"
@@ -11,7 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ns-tracker "0.2.2"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.edn/project.clj
+++ b/full.edn/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.edn "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.edn "0.8.0-SNAPSHOT"
   :description "Sugar for reading and writing EDN."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -10,8 +10,8 @@
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [fullcontact/full.time "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.time "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.http/project.clj
+++ b/full.http/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.http "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.http "0.8.0-SNAPSHOT"
   :description "Async HTTP client and server on top of http-kit and core.async."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -14,11 +14,11 @@
                  [compojure "1.3.4" :exclusions [clj-time]]
                  [javax.servlet/servlet-api "2.5"]
                  [ring-cors "0.1.7"]
-                 [fullcontact/camelsnake "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.json "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.metrics "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/camelsnake "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.json "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.metrics "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.http/project.clj
+++ b/full.http/project.clj
@@ -10,7 +10,7 @@
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [http-kit "2.1.18"]
+                 [http-kit "2.1.19"]
                  [compojure "1.3.4" :exclusions [clj-time]]
                  [javax.servlet/servlet-api "2.5"]
                  [ring-cors "0.1.7"]

--- a/full.json/project.clj
+++ b/full.json/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.json "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.json "0.8.0-SNAPSHOT"
   :description "Read and write JSON (Cheshire extension)."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -11,9 +11,9 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.5.0"]
-                 [fullcontact/full.time "0.7.5-SNAPSHOT"]
-                 [fullcontact/camelsnake "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.time "0.8.0-SNAPSHOT"]
+                 [fullcontact/camelsnake "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.liquibase/project.clj
+++ b/full.liquibase/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.liquibase "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.liquibase "0.8.0-SNAPSHOT"
   :description "Liquibase database schema creation/upgrading."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -15,7 +15,7 @@
                  [com.mattbertolini/liquibase-slf4j "1.2.1"
                   :exclusions [org.slf4j/slf4j-api
                                org.yaml/snakeyaml]]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.metrics/project.clj
+++ b/full.metrics/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.metrics "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.metrics "0.8.0-SNAPSHOT"
   :description "Clojure application metrics sugar for Riemann backend."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -13,8 +13,8 @@
                  [riemann-clojure-client "0.2.11" :exclusions [org.clojure/tools.logging
                                                                org.slf4j/slf4j-api]]
                  [com.climate/clj-newrelic "0.2.1"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
   :aot [full.metrics] ;clojure new relic extension doesn't work when aot'ed.
   :plugins [[lein-midje "3.1.3"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]]}})

--- a/full.rabbit/project.clj
+++ b/full.rabbit/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.rabbit "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.rabbit "0.8.0-SNAPSHOT"
   :description "RabbitMQ sugar on top of langohr."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -12,10 +12,10 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [com.novemberain/langohr "3.2.0"
                   :exclusions [cheshire]]
-                 [fullcontact/full.metrics "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.json "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.metrics "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.json "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/full.rollbar/project.clj
+++ b/full.rollbar/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.rollbar "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.rollbar "0.8.0-SNAPSHOT"
   :description "Library to ship exceptions and request information to the rollbar logging service."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -10,10 +10,10 @@
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [fullcontact/camelsnake "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.async "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]
-                 [fullcontact/full.http "0.7.5-SNAPSHOT"]]
+                 [fullcontact/camelsnake "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.async "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]
+                 [fullcontact/full.http "0.8.0-SNAPSHOT"]]
   :aot :all
 
   :plugins [[lein-midje "3.1.3"]]

--- a/full.time/project.clj
+++ b/full.time/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.time "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.time "0.8.0-SNAPSHOT"
   :description "clj-time add-on for simplified ISO-8601 format date/time handling."
 
   :url "https://github.com/fullcontact/full.monty"
@@ -11,7 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [clj-time "0.8.0"]
-                 [fullcontact/full.core "0.7.5-SNAPSHOT"]]
+                 [fullcontact/full.core "0.8.0-SNAPSHOT"]]
 
   :aot :all
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/full.monty "0.7.5-SNAPSHOT"
+(defproject fullcontact/full.monty "0.8.0-SNAPSHOT"
   :description "Minimalistic stack for building robust Clojure HTTP services."
 
   :url "https://github.com/fullcontact/full.monty"


### PR DESCRIPTION
When response's body is core.async channel, the response will be sent as a stream. Each value from channel
will be sent separately. If using json-response> middleware, each value from channel will be json encoded.

@zarlen @skazhy @mihailt @blendmaster 