### PR TITLE
full.core.config/opt: allow "false" values

### DIFF
--- a/full.core/src/full/core/config.clj
+++ b/full.core/src/full/core/config.clj
@@ -103,10 +103,8 @@
          (or (nil? mapper)
              (fn? mapper))]}
   (delay
-    (let [value (or (if (vector? sel)
-                      (get-in @_config sel)
-                      (get @_config sel))
-                    default)]
+    (let [conf-value (if (vector? sel) (get-in @_config sel) (get @_config sel))
+          value (if (some? conf-value) conf-value default)]
       (when (= ::undefined value)
         (throw (RuntimeException. (str "Option " sel " is not configured"))))
       (if mapper


### PR DESCRIPTION
Currently, if a property is defined as `foo: false`, loading it as such `(opt :foo)` will raise an exception (that it is not defined).
Having to do `(opt :foo :default false)` seems awkward and wrong.

/cc @zarlen @k7d 