### PR TITLE
full.http: passthrough httpkit "as" coercion param

### DIFF
--- a/full.http/src/full/http/client.clj
+++ b/full.http/src/full/http/client.clj
@@ -116,11 +116,12 @@
   return either response or exception."
   [{:keys [base-url resource url method params body headers basic-auth
            timeout form-params body-json-key-fn response-parser
-           follow-redirects?]
+           follow-redirects? as]
     :or {method :get
          body-json-key-fn ->camelCase
          response-parser kebab-case-json-response-parser
-         follow-redirects? true}}]
+         follow-redirects? true
+         as :auto}}]
   {:pre [(or url (and base-url resource))]}
   (let [req {:url (or url (str base-url "/" resource))
              :method method
@@ -130,7 +131,8 @@
              :form-params form-params
              :basic-auth basic-auth
              :timeout (* (or timeout @http-timeout) 1000)
-             :follow-redirects follow-redirects?}
+             :follow-redirects follow-redirects?
+             :as as}
         full-url (str (upper-case (name method))
                       " " (:url req)
                       (if (not-empty (:query-params req))


### PR DESCRIPTION
Among other things, the default :auto coercion treats
all non-200 status codes as plaintext, for reasons:

https://github.com/http-kit/http-kit/blob/0e53d3d883901a229c189c263b2a4f6c07e66a0e/src/java/org/httpkit/client/RespListener.java#L65

Thus, let clients specify their own coercion. :byte is the safest.